### PR TITLE
Proposal remove CNA from the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <title>Cloud Native Asturias</title>
   <meta content="" name="descriptison">
   <meta content="" name="keywords">
-  <meta property="og:title" content="CNA - Cloud Native Asturias">
+  <meta property="og:title" content="Cloud Native Asturias">
   <meta property="og:description" content="Official Web Site Cloud Native Asturias from Cloud Native and Computing Foundation">
   <meta property="og:image" content="https://cloudnativeasturias.com/assets/img/advertise.png">
   <meta property="og:url" content="https://cloudnativeasturias.com">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   </script>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title>CNA - Cloud Native Asturias</title>
+  <title>Cloud Native Asturias</title>
   <meta content="" name="descriptison">
   <meta content="" name="keywords">
   <meta property="og:title" content="CNA - Cloud Native Asturias">


### PR DESCRIPTION
For it would be ok to remove the "CNA" string from the title. Keep it only with Cloud Native Asturias looks simpler and not complicated